### PR TITLE
Enable more test for GKE and AKS

### DIFF
--- a/tetrateci/test_1.7.sh
+++ b/tetrateci/test_1.7.sh
@@ -30,8 +30,8 @@ if [[ ${CLUSTER} == "eks" ]]; then
 else
   go test -count=1 -tags=integ ./tests/integration/mixer/. -p 1 -test.v
   go test -count=1 -tags=integ ./tests/integration/mixer/envoy/...  -p 1 -test.v
-  go test -count=1 -tags=integ ./tests/integration/mixer/policy/. -p 1 -test.v
-  go test -count=1 -tags=integ ./tests/integration/mixer/telemetry/... -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/mixer/policy/. -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/mixer/telemetry/... -p 1 -test.v
   go test -count=1 -tags=integ -timeout 30m ./tests/integration/pilot/. -p 1 -test.v
   go test -count=1 -tags=integ -timeout 30m ./tests/integration/pilot/vm/. -run='TestTrafficShifting|TestVmOS' -p 1 -test.v
   go test -count=1 -tags=integ -timeout 30m ./tests/integration/pilot/ingress/. -p 1 -test.v

--- a/tetrateci/test_1.7.sh
+++ b/tetrateci/test_1.7.sh
@@ -9,13 +9,11 @@ fi
 
 go test -count=1 -tags=integ ./tests/integration/operator/...  -p 1  -test.v
 go test -count=1 -tags=integ ./tests/integration/galley/...  -p 1  -test.v
-go test -count=1 -tags=integ -timeout 30m -run='TestWait|TestVersion|TestDescribe|TestAddToAndRemoveFromMesh|TestProxyConfig|TestProxyStatus|TestAuthZCheck|TestMain|TestMirroring|TestMirroringExternalSerivce|TestTraffic' ./tests/integration/pilot/ -p 1 -test.v 
 go test -count=1 -tags=integ ./tests/integration/pilot/analysis/... -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/pilot/locality/... -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/pilot/revisions/... -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/mixer/outboundtrafficpolicy  -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/telemetry/outboundtrafficpolicy -p 1 -test.v
-go test -count=1 -tags=integ -timeout 30m -run='TestStatsFilter|TestSetup|TestIstioctlMetrics|TestStatsFilter|TestWASMTcpMetric|TestWasmStatsFilter|TestMain|TestCustomizeMetrics' ./tests/integration/telemetry/stats/... -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/security/ca_custom_root/... -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/security/cert_provision_prometheus/... -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/security/filebased_tls_origination/... -p 1 -test.v
@@ -24,7 +22,26 @@ go test -count=1 -tags=integ ./tests/integration/security/mtlsk8sca/... -p 1 -te
 go test -count=1 -tags=integ ./tests/integration/security/sds_egress/... -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/security/sds_tls_origination/... -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/security/webhook/... -p 1 -test.v
-go test -count=1 -tags=integ -run 'TestAuthorization_mTLS|TestAuthorization_JWT|TestAuthorization_WorkloadSelector|TestAuthorization_Deny|TestAuthorization_NegativeMatch|TestAuthorization_EgressGateway|TestAuthorization_TCP|TestAuthorization_Conditions|TestAuthorization_GRPC|TestAuthorization_Path|TestRequestAuthentication|TestMain|TestMtlsHealthCheck|TestPassThroughFilterChain' ./tests/integration/security/.  -p 1 -test.v
+
+if [[ ${CLUSTER} == "eks" ]]; then
+  go test -count=1 -tags=integ -timeout 30m -run='TestWait|TestVersion|TestDescribe|TestAddToAndRemoveFromMesh|TestProxyConfig|TestProxyStatus|TestAuthZCheck|TestMain|TestMirroring|TestMirroringExternalSerivce|TestTraffic' ./tests/integration/pilot/ -p 1 -test.v 
+  go test -count=1 -tags=integ -run 'TestAuthorization_mTLS|TestAuthorization_JWT|TestAuthorization_WorkloadSelector|TestAuthorization_Deny|TestAuthorization_NegativeMatch|TestAuthorization_EgressGateway|TestAuthorization_TCP|TestAuthorization_Conditions|TestAuthorization_GRPC|TestAuthorization_Path|TestRequestAuthentication|TestMain|TestMtlsHealthCheck|TestPassThroughFilterChain' ./tests/integration/security/.  -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m -run='TestStatsFilter|TestSetup|TestIstioctlMetrics|TestStatsFilter|TestWASMTcpMetric|TestWasmStatsFilter|TestMain|TestCustomizeMetrics' ./tests/integration/telemetry/stats/... -p 1 -test.v
+else
+  go test -count=1 -tags=integ ./tests/integration/mixer/. -p 1 -test.v
+  go test -count=1 -tags=integ ./tests/integration/mixer/envoy/...  -p 1 -test.v
+  go test -count=1 -tags=integ ./tests/integration/mixer/policy/. -p 1 -test.v
+  go test -count=1 -tags=integ ./tests/integration/mixer/telemetry/... -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/pilot/. -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/pilot/vm/. -run='TestTrafficShifting|TestVmOS' -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/pilot/ingress/. -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/security/.  -p 1 -test.v
+  go test -count=1 -tags=integ ./tests/integration/security/sds_ingress/.  -p 1 -test.v
+  go test -count=1 -tags=integ ./tests/integration/security/sds_ingress_k8sca/.  -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/telemetry/. -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/telemetry/stats/... -p 1 -test.v
+fi
+
 
 if [[ ${CLUSTER} != "gke" ]]; then
   go test -count=1 -tags=integ ./tests/integration/security/chiron/... -p 1 -test.v

--- a/tetrateci/test_1.8.sh
+++ b/tetrateci/test_1.8.sh
@@ -9,10 +9,8 @@ fi
 
 go test -count=1 -tags=integ ./tests/integration/helm/... -istio.test.skipVM true -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/operator/...  -istio.test.skipVM true -p 1  -test.v
-go test -count=1 -tags=integ -timeout 30m -run='TestEmptyCluster|TestFileOnly|TestDirectoryWithoutRecursion|TestDirectoryWithRecursion|TestInvalidFileError|TestJsonInputFile|TestJsonOutput|TestKubeOnly|TestFileAndKubeCombined|TestAllNamespaces|TestTimeout|TestErrorLine|TestWait|TestVersion|TestDescribe|TestAddToAndRemoveFromMesh|TestProxyConfig|TestProxyStatus|TestAuthZCheck|TestLocality|TestMain|TestMirroring|TestMirroringExternalService|TestTproxy|TestValidation|TestEnsureNoMissingCRDs|TestWebhook' ./tests/integration/pilot/ -istio.test.skipVM true -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/pilot/analysis/... -istio.test.skipVM true -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/pilot/revisions/... -istio.test.skipVM true -p 1 -test.v
-go test -count=1 -tags=integ -timeout 30m -run='TestStatsFilter|TestStatsTCPFilter|TestSetup|TestIstioctlMetrics|TestTcpMetric|TestStatsFilter|TestWASMTcpMetric|TestWasmStatsFilter|TestMain|TestCustomizeMetrics' ./tests/integration/telemetry/stats/... -istio.test.skipVM true -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/telemetry/requestclassification/... -istio.test.skipVM true -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/telemetry/outboundtrafficpolicy/... -istio.test.skipVM true -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/security/ca_custom_root/... -istio.test.skipVM true -p 1 -test.v
@@ -24,10 +22,23 @@ go test -count=1 -tags=integ ./tests/integration/security/sds_egress/... -istio.
 go test -count=1 -tags=integ ./tests/integration/security/sds_tls_origination/... -istio.test.skipVM true -p 1 -test.v
 go test -count=1 -tags=integ ./tests/integration/security/webhook/... -istio.test.skipVM true -p 1 -test.v
 
+if [[ ${CLUSTER} == "eks" ]]; then
+ go test -count=1 -tags=integ -timeout 30m ./tests/integration/telemetry/stats/... -run='TestStatsFilter|TestSetup|TestIstioctlMetrics|TestStatsFilter|TestWASMTcpMetric|TestWasmStatsFilter|TestMain|TestCustomizeMetrics' -istio.test.skipVM true -p 1 -test.v
+ go test -count=1 -tags=integ -timeout 30m ./tests/integration/pilot/ -run='TestEmptyCluster|TestFileOnly|TestDirectoryWithoutRecursion|TestDirectoryWithRecursion|TestInvalidFileError|TestJsonInputFile|TestJsonOutput|TestKubeOnly|TestFileAndKubeCombined|TestAllNamespaces|TestTimeout|TestErrorLine|TestWait|TestVersion|TestDescribe|TestAddToAndRemoveFromMesh|TestProxyConfig|TestProxyStatus|TestAuthZCheck|TestLocality|TestMain|TestMirroring|TestMirroringExternalService|TestTproxy|TestValidation|TestEnsureNoMissingCRDs|TestWebhook' -istio.test.skipVM true -p 1 -test.v
+else
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/security/. -istio.test.skipVM true -p 1 -test.v
+  go test -count=1 -tags=integ ./tests/integration/security/sds_ingress/. -istio.test.skipVM true -p 1 -test.v
+  go test -count=1 -tags=integ ./tests/integration/security/sds_ingress_gateway/. -istio.test.skipVM true -p 1 -test.v
+  go test -count=1 -tags=integ ./tests/integration/security/sds_ingress_k8sca/. -istio.test.skipVM true -p 1 -test.v
+  go test -count=1 -tags=integ ./tests/integration/telemetry/stackdriver/... -run='TestStackdriverHTTPAuditLogging|TestVMTelemetry' -istio.test.skipVM true -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/telemetry/stats/... -istio.test.skipVM true -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/pilot/ -run='TestAddToAndRemoveFromMesh|TestAllNamespaces|TestAuthZCheck|TestDescribe|TestDirectoryWithRecursion|TestDirectoryWithoutRecursion|TestEmptyCluster|TestEnsureNoMissingCRDs|TestErrorLine|TestFileAndKubeCombined|TestFileOnly|TestGateway|TestIngress|TestInvalidFileError|TestJsonInputFile|TestJsonOutput|TestKubeOnly|TestLocality|TestMirroring|TestMirroringExternalService|TestProxyConfig|TestProxyStatus|TestTraffic|TestVMRegistrationLifecycle|TestValidation|TestVersion|TestWait|TestWebhook' -istio.test.skipVM true -p 1 -test.v
+fi
+
 if [[ ${CLUSTER} != "gke" ]]; then
   go test -count=1 -tags=integ ./tests/integration/security/chiron/... -istio.test.skipVM true -p 1 -test.v
 fi
 
-if [[ $CLUSTER != "aks" ]]; then
+if [[ ${CLUSTER} != "aks" ]]; then
   go test -count=1 -tags=integ ./tests/integration/pilot/cni/... ${CLUSTERFLAGS} -istio.test.skipVM true -p 1 -test.v
 fi

--- a/tetrateci/test_1.8.sh
+++ b/tetrateci/test_1.8.sh
@@ -30,9 +30,14 @@ else
   go test -count=1 -tags=integ ./tests/integration/security/sds_ingress/. -istio.test.skipVM true -p 1 -test.v
   go test -count=1 -tags=integ ./tests/integration/security/sds_ingress_gateway/. -istio.test.skipVM true -p 1 -test.v
   go test -count=1 -tags=integ ./tests/integration/security/sds_ingress_k8sca/. -istio.test.skipVM true -p 1 -test.v
-  go test -count=1 -tags=integ ./tests/integration/telemetry/stackdriver/... -run='TestStackdriverHTTPAuditLogging|TestVMTelemetry' -istio.test.skipVM true -p 1 -test.v
-  go test -count=1 -tags=integ -timeout 30m ./tests/integration/telemetry/stats/... -istio.test.skipVM true -p 1 -test.v
-  go test -count=1 -tags=integ -timeout 30m ./tests/integration/pilot/ -run='TestAddToAndRemoveFromMesh|TestAllNamespaces|TestAuthZCheck|TestDescribe|TestDirectoryWithRecursion|TestDirectoryWithoutRecursion|TestEmptyCluster|TestEnsureNoMissingCRDs|TestErrorLine|TestFileAndKubeCombined|TestFileOnly|TestGateway|TestIngress|TestInvalidFileError|TestJsonInputFile|TestJsonOutput|TestKubeOnly|TestLocality|TestMirroring|TestMirroringExternalService|TestProxyConfig|TestProxyStatus|TestTraffic|TestVMRegistrationLifecycle|TestValidation|TestVersion|TestWait|TestWebhook' -istio.test.skipVM true -p 1 -test.v
+  go test -count=1 -tags=integ -timeout 30m ./tests/integration/pilot/ -run='TestAddToAndRemoveFromMesh|TestAllNamespaces|TestAuthZCheck|TestDescribe|TestDirectoryWithRecursion|TestDirectoryWithoutRecursion|TestEmptyCluster|TestEnsureNoMissingCRDs|TestErrorLine|TestFileAndKubeCombined|TestFileOnly|TestGateway|TestIngress|TestInvalidFileError|TestIstioctlMetrics|TestJsonInputFile|TestJsonOutput|TestKubeOnly|TestLocality|TestMirroring|TestMirroringExternalService|TestProxyConfig|TestProxyStatus|TestStatsFilter|TestTcpMetric|TestTraffic|TestValidation|TestVersion|TestWASMTcpMetric|TestWait|TestWasmStatsFilter|TestWebhook' -istio.test.skipVM true -p 1 -test.v
+
+  if [[ ${CLUSTER} == "aks" ]]; then
+    go test -count=1 -tags=integ -timeout 30m -run='TestStatsFilter|TestStatsTCPFilter|TestSetup|TestIstioctlMetrics|TestTcpMetric|TestStatsFilter|TestWASMTcpMetric|TestWasmStatsFilter|TestMain|TestCustomizeMetrics' ./tests/integration/telemetry/stats/... -istio.test.skipVM true -p 1 -test.v
+  else
+    go test -count=1 -tags=integ ./tests/integration/telemetry/stackdriver/... -run='TestStackdriverHTTPAuditLogging|TestVMTelemetry' -istio.test.skipVM true -p 1 -test.v
+    go test -count=1 -tags=integ -timeout 30m ./tests/integration/telemetry/stats/... -istio.test.skipVM true -p 1 -test.v
+  fi
 fi
 
 if [[ ${CLUSTER} != "gke" ]]; then


### PR DESCRIPTION
Some tests fail in EKS due to ingress issues, but they can be enabled for
the other distros.

This runs in GKE and I'm going to run them in AKS