### PR TITLE
PATCH: For nodeport services, consider private ip if public ip is not set at k8s node

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -464,6 +464,14 @@ func (c *Controller) onNodeEvent(obj interface{}, event model.Event) error {
 			}
 		}
 		if k8sNode.address == "" {
+			for _, address := range node.Status.Addresses {
+				if address.Type == v1.NodeInternalIP && address.Address != "" {
+					k8sNode.address = address.Address
+					break
+				}
+			}
+		}
+		if k8sNode.address == "" {
 			return nil
 		}
 


### PR DESCRIPTION
```
vikas@ gw-canary () $ nodes -o wide
NAME                      STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE       KERNEL-VERSION     CONTAINER-RUNTIME
cluster-0-control-plane   Ready    master   19h   v1.17.5   172.18.0.2    <none>        Ubuntu 19.10   5.8.0-43-generic 
```
Please note no `ExternalIP`. With current changes private node ip is used by the istiod in the nodeport svc's external addresses