### PR TITLE
handle NodePort services with external traffic policy set to Local

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -409,4 +409,8 @@ var (
 	PilotEnableLoopBlockers = env.RegisterBoolVar("PILOT_ENABLE_LOOP_BLOCKER", true,
 		"If enabled, Envoy will be configured to prevent traffic directly the the inbound/outbound "+
 			"ports (15001/15006). This prevents traffic loops. This option will be removed, and considered always enabled, in 1.9.").Get()
+
+	PilotEnableEndpointFilterForLocalTrafficPolicy = env.RegisterBoolVar("PILOT_ENABLE_ENDPOINT_FILTER_FOR_LOCAL_TRAFFIC_POLICY", false,
+		"This is applicable only to NodePort services whose external traffic policy is set to Local. It filters out "+
+			"all node addresses which do not have a workload").Get()
 )

--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -409,8 +409,4 @@ var (
 	PilotEnableLoopBlockers = env.RegisterBoolVar("PILOT_ENABLE_LOOP_BLOCKER", true,
 		"If enabled, Envoy will be configured to prevent traffic directly the the inbound/outbound "+
 			"ports (15001/15006). This prevents traffic loops. This option will be removed, and considered always enabled, in 1.9.").Get()
-
-	PilotEnableEndpointFilterForLocalTrafficPolicy = env.RegisterBoolVar("PILOT_ENABLE_ENDPOINT_FILTER_FOR_LOCAL_TRAFFIC_POLICY", false,
-		"This is applicable only to NodePort services whose external traffic policy is set to Local. It filters out "+
-			"all node addresses which do not have a workload").Get()
 )

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -327,6 +327,8 @@ const (
 	DebugTrigger TriggerReason = "debug"
 	// Describes a push triggered for a Secret change
 	SecretTrigger TriggerReason = "secret"
+	// Describes a push triggered due to node event
+	NodeTrigger TriggerReason = "node"
 )
 
 // Merge two update requests together

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -239,6 +239,13 @@ type Controller struct {
 	// Stores a map of workload instance name/namespace to address
 	workloadInstancesIPsByName map[string]string
 
+	// serviceToWorkloadNodeMap is a mapping of NodePort services to the list of kubernetes node names
+	// on which there is at least one workload belonging to the service is running. This is needed to handle
+	// node-port services with external traffic policy type set to Local (default is Cluster). This is because
+	// when it is set to local and traffic is sent to a node not hosting a workload, it will be dropped. This
+	// happens intermittently based on the node which takes the traffic.
+	serviceToWorkloadNodeMap map[host.Name]map[string][]string
+
 	// CIDR ranger based on path-compressed prefix trie
 	ranger cidranger.Ranger
 
@@ -275,6 +282,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		workloadInstancesIPsByName:  make(map[string]string),
 		registryServiceNameGateways: make(map[host.Name]uint32),
 		networkGateways:             make(map[host.Name]map[string][]*model.Gateway),
+		serviceToWorkloadNodeMap:    make(map[host.Name]map[string][]string),
 		networksWatcher:             options.NetworksWatcher,
 		metrics:                     options.Metrics,
 		syncInterval:                options.GetSyncInterval(),
@@ -319,6 +327,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 		})
 	})
 	registerHandlers(c.pods.informer, c.queue, "Pods", c.pods.onEvent, nil)
+	c.AppendWorkloadHandler(c.rebuildHostToNodeIndexOnPodEvent)
 
 	return c
 }
@@ -381,6 +390,7 @@ func (c *Controller) onServiceEvent(curr interface{}, event model.Event) error {
 		delete(c.nodeSelectorsForServices, svcConv.Hostname)
 		delete(c.externalNameSvcInstanceMap, svcConv.Hostname)
 		delete(c.networkGateways, svcConv.Hostname)
+		delete(c.serviceToWorkloadNodeMap, svcConv.Hostname)
 		c.Unlock()
 	default:
 		if isNodePortGatewayService(svc) {
@@ -448,6 +458,12 @@ func (c *Controller) onNodeEvent(obj interface{}, event model.Event) error {
 		updatedNeeded = true
 		c.Lock()
 		delete(c.nodeInfoMap, node.Name)
+
+		// We should remove the node for all the services that
+		// had a workload there as we don't want to route traffic
+		for h := range c.serviceToWorkloadNodeMap {
+			delete(c.serviceToWorkloadNodeMap[h], node.Name)
+		}
 		c.Unlock()
 	} else {
 		k8sNode := kubernetesNode{labels: node.Labels}
@@ -1166,4 +1182,35 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) {
 // AppendWorkloadHandler implements a service catalog operation
 func (c *Controller) AppendWorkloadHandler(f func(*model.WorkloadInstance, model.Event)) {
 	c.workloadHandlers = append(c.workloadHandlers, f)
+}
+
+func (c *Controller) rebuildHostToNodeIndexOnPodEvent(wi *model.WorkloadInstance, _ model.Event) {
+	if !features.PilotEnableEndpointFilterForLocalTrafficPolicy {
+		return
+	}
+	dummyPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: wi.Namespace,
+			Labels:    wi.Endpoint.Labels,
+		},
+	}
+	k8ssvcs, err := getPodServices(c.serviceLister, dummyPod)
+	if err != nil {
+		return
+	}
+	for _, k8ssvc := range k8ssvcs {
+		// Restrict processing only to services of type NodePort
+		// with external traffic policy set to Local
+		if k8ssvc.Spec.Type != v1.ServiceTypeNodePort ||
+			k8ssvc.Spec.ExternalTrafficPolicy != v1.ServiceExternalTrafficPolicyTypeLocal {
+			continue
+		}
+		hostname := kube.ServiceHostname(k8ssvc.Name, k8ssvc.Namespace, c.domainSuffix)
+		c.RLock()
+		svc := c.servicesMap[hostname]
+		c.RUnlock()
+		if svc != nil {
+			c.updateServiceNodePortAddresses(svc)
+		}
+	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	coreV1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -436,8 +438,8 @@ func TestGetProxyServiceInstances(t *testing.T) {
 			if len(metaServices) != 1 {
 				t.Fatalf("expected 1 instance, got %v", len(metaServices))
 			}
-			if !reflect.DeepEqual(expected, metaServices[0]) {
-				t.Fatalf("expected instance %v, got %v", expected, metaServices[0])
+			if diff := cmp.Diff(expected, metaServices[0], cmpopts.IgnoreFields(model.Service{}, "Mutex")); diff != "" {
+				t.Fatalf("expected instance %v, got %v.\nDiff=%s", expected, metaServices[0], diff)
 			}
 
 			// Test that we first look up instances by Proxy pod
@@ -498,13 +500,14 @@ func TestGetProxyServiceInstances(t *testing.T) {
 					TLSMode:        model.DisabledTLSModeLabel,
 					WorkloadName:   "pod2",
 					Namespace:      "nsa",
+					NodeName:       "node1",
 				},
 			}
 			if len(podServices) != 1 {
 				t.Fatalf("expected 1 instance, got %v", len(podServices))
 			}
-			if !reflect.DeepEqual(expected, podServices[0]) {
-				t.Fatalf("expected instance %v, got %v", expected, podServices[0])
+			if diff := cmp.Diff(expected, podServices[0], cmpopts.IgnoreFields(model.Service{}, "Mutex")); diff != "" {
+				t.Fatalf("expected instance %v, got %v\nDiff=%s", expected, podServices[0], diff)
 			}
 
 			// 2. pod with `istio-locality` label, ignore node label.
@@ -560,13 +563,14 @@ func TestGetProxyServiceInstances(t *testing.T) {
 					TLSMode:        model.DisabledTLSModeLabel,
 					WorkloadName:   "pod3",
 					Namespace:      "nsa",
+					NodeName:       "node1",
 				},
 			}
 			if len(podServices) != 1 {
 				t.Fatalf("expected 1 instance, got %v", len(podServices))
 			}
-			if !reflect.DeepEqual(expected, podServices[0]) {
-				t.Fatalf("expected instance %v, got %v", expected, podServices[0])
+			if diff := cmp.Diff(expected, podServices[0], cmpopts.IgnoreFields(model.Service{}, "Mutex")); diff != "" {
+				t.Fatalf("expected instance %v, got %v\nDiff=%s", expected, podServices[0], diff)
 			}
 		})
 	}

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
@@ -28,7 +28,7 @@ import (
 	"istio.io/pkg/log"
 )
 
-// A stateful IstioEndpoint builder with metadata used to build IstioEndpoint
+// EndpointBuilder is a stateful IstioEndpoint builder with metadata used to build IstioEndpoint
 type EndpointBuilder struct {
 	controller controllerInterface
 
@@ -39,16 +39,18 @@ type EndpointBuilder struct {
 	tlsMode        string
 	workloadName   string
 	namespace      string
+	nodeName       string
 }
 
 func NewEndpointBuilder(c controllerInterface, pod *v1.Pod) *EndpointBuilder {
-	locality, sa, wn, namespace := "", "", "", ""
+	locality, sa, wn, namespace, nodeName := "", "", "", "", ""
 	var podLabels labels.Instance
 	if pod != nil {
 		locality = c.getPodLocality(pod)
 		sa = kube.SecureNamingSAN(pod)
 		podLabels = pod.Labels
 		namespace = pod.Namespace
+		nodeName = pod.Spec.NodeName
 	}
 	dm, _ := kubeUtil.GetDeployMetaFromPod(pod)
 	if dm != nil {
@@ -66,6 +68,7 @@ func NewEndpointBuilder(c controllerInterface, pod *v1.Pod) *EndpointBuilder {
 		tlsMode:      kube.PodTLSMode(pod),
 		workloadName: wn,
 		namespace:    namespace,
+		nodeName:     nodeName,
 	}
 }
 
@@ -128,6 +131,7 @@ func (b *EndpointBuilder) buildIstioEndpoint(
 		Network:         b.endpointNetwork(endpointAddress),
 		WorkloadName:    b.workloadName,
 		Namespace:       b.namespace,
+		NodeName:        b.nodeName,
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/network.go
+++ b/pilot/pkg/serviceregistry/kube/controller/network.go
@@ -227,7 +227,7 @@ func (c *Controller) updateServiceNodePortAddresses(svcs ...*model.Service) bool
 			nodesWithEndpoints := getWorkloadNodeLocations(endpoints)
 			log.Debugf("---> svc:%s nodesWithEndpoints = %#v", svc.Hostname, nodesWithEndpoints)
 			c.Lock()
-			c.serviceToWorkloadNodeMap[svc.Hostname] = nodesWithEndpoints
+			c.serviceToWorkloadNodesMap[svc.Hostname] = nodesWithEndpoints
 			c.Unlock()
 		}
 
@@ -289,7 +289,7 @@ func (c *Controller) updateClusterExternalAddressesForNodePortServices(nodeSelec
 }
 
 func (c *Controller) containsWorkloadForLocalTrafficService(svc *model.Service, nodeName string) bool {
-	_, f := c.serviceToWorkloadNodeMap[svc.Hostname][nodeName]
+	_, f := c.serviceToWorkloadNodesMap[svc.Hostname][nodeName]
 	return f
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller/nodeport_ext_address_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/nodeport_ext_address_test.go
@@ -1,0 +1,157 @@
+package controller
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/config/host"
+	"istio.io/istio/pkg/config/labels"
+)
+
+func TestExtractNodeNameFromEndpoints(t *testing.T) {
+	epOnNode1 := &model.IstioEndpoint{
+		NodeName:        "node1",
+		EndpointPort:    8080,
+		WorkloadName:    "app-1",
+		Namespace:       "app-ns",
+		ServicePortName: "http-app",
+	}
+	epOnNode2 := &model.IstioEndpoint{
+		NodeName:        "node2",
+		EndpointPort:    8080,
+		WorkloadName:    "app-1",
+		Namespace:       "app-ns",
+		ServicePortName: "http-app",
+	}
+	epWithoutNodeName := &model.IstioEndpoint{
+		EndpointPort:    8090,
+		WorkloadName:    "app-1",
+		Namespace:       "app-ns",
+		ServicePortName: "http-app",
+	}
+	for _, tt := range []struct {
+		name          string
+		endpoints     []*model.IstioEndpoint
+		expectedNodes map[string]struct{}
+	}{
+		{
+			name:          "workload with single endpoint on node1",
+			endpoints:     []*model.IstioEndpoint{epOnNode1},
+			expectedNodes: map[string]struct{}{"node1": {}},
+		},
+		{
+			name:          "workload with multiple endpoints on different nodes",
+			endpoints:     []*model.IstioEndpoint{epOnNode1, epOnNode2},
+			expectedNodes: map[string]struct{}{"node1": {}, "node2": {}},
+		},
+		{
+			name:          "workload without node-name filled",
+			endpoints:     []*model.IstioEndpoint{epWithoutNodeName},
+			expectedNodes: map[string]struct{}{},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			actualNodes := getWorkloadNodeLocations(tt.endpoints)
+			if diff := cmp.Diff(actualNodes, tt.expectedNodes); diff != "" {
+				t.Fatalf("diff:\n%s\nexpected:\n%s\nactual:\n%s\n", diff, tt.expectedNodes, actualNodes)
+			}
+		})
+	}
+}
+
+func TestUpdateClusterExternalAddressesForNodePortServices(t *testing.T) {
+	clusterNodePortSvc := &model.Service{
+		Hostname: host.Name("cluster-svc.ingress.svc.cluster.local"),
+		Attributes: model.ServiceAttributes{
+			ExternalTrafficPolicy: model.ExternalTrafficPolicyCluster,
+		},
+	}
+	localNodePortSvc := &model.Service{
+		Hostname: host.Name("local-svc.ingress.svc.cluster.local"),
+		Attributes: model.ServiceAttributes{
+			ExternalTrafficPolicy: model.ExternalTrafficPolicyLocal,
+		},
+	}
+	clusterID := "test-cluster"
+	nodes := map[string]kubernetesNode{
+		"node1": {address: "10.10.10.10", labels: labels.Instance{NodeZoneLabelGA: "east"}},
+		"node2": {address: "10.10.10.20", labels: labels.Instance{NodeZoneLabelGA: "west"}},
+		"node3": {address: "10.10.10.30", labels: labels.Instance{NodeZoneLabelGA: "east"}},
+		"node4": {address: "10.10.10.40", labels: labels.Instance{NodeZoneLabelGA: "west"}},
+	}
+	for _, tt := range []struct {
+		name                 string
+		service              *model.Service
+		workloadHostingNodes []string
+		nodeLabelSelector    labels.Instance
+		expectedAddresses    []string
+	}{
+		{
+			name:                 "external traffic policy is Cluster in 4 node cluster",
+			service:              clusterNodePortSvc,
+			workloadHostingNodes: []string{"node1", "node2"},
+			expectedAddresses:    []string{"10.10.10.10", "10.10.10.20", "10.10.10.30", "10.10.10.40"},
+			nodeLabelSelector:    labels.Instance{},
+		},
+		{
+			name:                 "external traffic policy is Local in 4 node cluster",
+			service:              localNodePortSvc,
+			workloadHostingNodes: []string{"node1", "node2"},
+			expectedAddresses:    []string{"10.10.10.10", "10.10.10.20"},
+			nodeLabelSelector:    labels.Instance{},
+		},
+		{
+			name:                 "external traffic policy is Cluster with node-label selector specified",
+			service:              clusterNodePortSvc,
+			workloadHostingNodes: []string{"node1", "node3"},
+			expectedAddresses:    []string{"10.10.10.10", "10.10.10.30"},
+			nodeLabelSelector:    labels.Instance{NodeZoneLabelGA: "east"},
+		},
+		{
+			name:                 "external traffic policy is Local with node-label selector specified",
+			service:              localNodePortSvc,
+			workloadHostingNodes: []string{"node3"},
+			expectedAddresses:    []string{"10.10.10.30"},
+			nodeLabelSelector:    labels.Instance{NodeZoneLabelGA: "east"},
+		},
+		{
+			name:                 "external traffic policy is Local with nil node-selector",
+			service:              localNodePortSvc,
+			workloadHostingNodes: []string{"node3", "node2"},
+			expectedAddresses:    []string{"10.10.10.20", "10.10.10.30"},
+			nodeLabelSelector:    nil,
+		},
+		{
+			name:                 "node-label selector does not match",
+			service:              clusterNodePortSvc,
+			workloadHostingNodes: []string{"node1", "node3"},
+			expectedAddresses:    nil,
+			nodeLabelSelector:    labels.Instance{NodeZoneLabelGA: "south"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Controller{
+				clusterID:                clusterID,
+				nodeInfoMap:              nodes,
+				serviceToWorkloadNodeMap: map[host.Name]map[string]struct{}{},
+			}
+			// Copy because the function mutates
+			svcCopied := tt.service.DeepCopy()
+			c.serviceToWorkloadNodeMap[svcCopied.Hostname] = map[string]struct{}{}
+			for _, h := range tt.workloadHostingNodes {
+				c.serviceToWorkloadNodeMap[svcCopied.Hostname][h] = struct{}{}
+			}
+
+			c.updateClusterExternalAddressesForNodePortServices(tt.nodeLabelSelector, svcCopied)
+			actualAddresses := svcCopied.Attributes.ClusterExternalAddresses[clusterID]
+			sort.Strings(tt.expectedAddresses)
+			sort.Strings(actualAddresses)
+			if diff := cmp.Diff(actualAddresses, tt.expectedAddresses); diff != "" {
+				t.Fatalf("unexpected external addresses set: diff = %s", diff)
+			}
+		})
+	}
+}

--- a/pilot/pkg/serviceregistry/kube/controller/nodeport_ext_address_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/nodeport_ext_address_test.go
@@ -134,15 +134,15 @@ func TestUpdateClusterExternalAddressesForNodePortServices(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Controller{
-				clusterID:                clusterID,
-				nodeInfoMap:              nodes,
-				serviceToWorkloadNodeMap: map[host.Name]map[string]struct{}{},
+				clusterID:                 clusterID,
+				nodeInfoMap:               nodes,
+				serviceToWorkloadNodesMap: map[host.Name]map[string]struct{}{},
 			}
 			// Copy because the function mutates
 			svcCopied := tt.service.DeepCopy()
-			c.serviceToWorkloadNodeMap[svcCopied.Hostname] = map[string]struct{}{}
+			c.serviceToWorkloadNodesMap[svcCopied.Hostname] = map[string]struct{}{}
 			for _, h := range tt.workloadHostingNodes {
-				c.serviceToWorkloadNodeMap[svcCopied.Hostname][h] = struct{}{}
+				c.serviceToWorkloadNodesMap[svcCopied.Hostname][h] = struct{}{}
 			}
 
 			c.updateClusterExternalAddressesForNodePortServices(tt.nodeLabelSelector, svcCopied)

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -22,7 +22,6 @@ import (
 	coreV1 "k8s.io/api/core/v1"
 
 	"istio.io/api/annotation"
-	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/constants"
@@ -130,9 +129,7 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 			portMap[uint32(p.Port)] = uint32(p.NodePort)
 		}
 		istioService.Attributes.ClusterExternalPorts = map[string]map[uint32]uint32{clusterID: portMap}
-		if features.PilotEnableEndpointFilterForLocalTrafficPolicy {
-			istioService.Attributes.ExternalTrafficPolicy = model.ConvertToModelExternalTrafficPolicy(svc.Spec.ExternalTrafficPolicy)
-		}
+		istioService.Attributes.ExternalTrafficPolicy = model.ConvertToModelExternalTrafficPolicy(svc.Spec.ExternalTrafficPolicy)
 
 		// address mappings will be done elsewhere
 	case coreV1.ServiceTypeLoadBalancer:

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -22,6 +22,7 @@ import (
 	coreV1 "k8s.io/api/core/v1"
 
 	"istio.io/api/annotation"
+	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/config/constants"
@@ -129,6 +130,10 @@ func ConvertService(svc coreV1.Service, domainSuffix string, clusterID string) *
 			portMap[uint32(p.Port)] = uint32(p.NodePort)
 		}
 		istioService.Attributes.ClusterExternalPorts = map[string]map[uint32]uint32{clusterID: portMap}
+		if features.PilotEnableEndpointFilterForLocalTrafficPolicy {
+			istioService.Attributes.ExternalTrafficPolicy = model.ConvertToModelExternalTrafficPolicy(svc.Spec.ExternalTrafficPolicy)
+		}
+
 		// address mappings will be done elsewhere
 	case coreV1.ServiceTypeLoadBalancer:
 		if len(svc.Status.LoadBalancer.Ingress) > 0 {


### PR DESCRIPTION
Support node port services whose external traffic policy is set to `Local`. Currently, Istio assumes that it will be `Cluster` and this is causing issues in some scenarios.