### PR TITLE
Delete deprecated env

### DIFF
--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -46,7 +46,6 @@ if [[ ${BUILD} == "fips" ]]; then
 	sed -i "s/.*as distroless/${PROXY_DISTROLESS_BASE_ESCAPED}/" ${BASEDIR}/pilot/docker/Dockerfile.pilot
 	sed -i "s/.*as distroless/${PROXY_DISTROLESS_BASE_ESCAPED}/" ${BASEDIR}/operator/docker/Dockerfile.operator
 
-    export ISTIO_ENVOY_WASM_BASE_URL=https://storage.googleapis.com/istio-build/proxy 
     export ISTIO_ENVOY_BASE_URL=https://storage.googleapis.com/getistio-build/proxy-fips
 fi
 


### PR DESCRIPTION
ISTIO_ENVOY_WASM_BASE_URL is not used anywhere.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>