### PR TITLE
Copy Envoy binary to CentOS path.

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -76,6 +76,14 @@ jobs:
         env:
           BUILD_WITH_CONTAINER: 1 
         run: make push_release
+      
+      - name: Put CentOS binary
+        if: ${{ steps.check_already_built.outputs.should_build == '1' }}
+        # Copy the binary built on Ubuntu to CentOS path - this binar cannot run on CentOS/RHEL 7, but fine with CentOS 8.
+        # The point is that we cannot build FIPS binary directly on CentOS 7 due to the constraints described in the BoringCrypto certification.
+        run: |
+          SHA=$(git rev-parse --verify HEAD)
+          gsutil cp ${RELEASE_GCS_PATH}/envoy-alpha-${SHA}.tar.gz ${RELEASE_GCS_PATH}/envoy-centos-alpha-${SHA}.tar.gz
 
   make_release:
     name: release-builder-run (${{ github.event.inputs.tag }})


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>