### PR TITLE
Dont error out if the proxy is not found

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Check if already built
         id: check_already_built
         run: |
+          set +e
           SHA=$(git rev-parse --verify HEAD)
           gsutil ls ${RELEASE_GCS_PATH} | grep ${SHA}
           echo ::set-output name=should_build::$?


### PR DESCRIPTION
If the proxy is not found the command returns 1 as exit code and since the shell is started with a `-e` the process exits. Where as an exit code of 1 only means the proxy is not found and we would need to build it.