### PR TITLE
Bumps Go to 1.16.9b7 for 1.11 FIPS Builds

### DIFF
--- a/tetrateci/setup_boring_go.sh
+++ b/tetrateci/setup_boring_go.sh
@@ -10,7 +10,7 @@ if $(grep -q "1.8" <<< $TAG || grep -q "1.9" <<< $TAG); then
 fi
 
 if $(grep -q "1.10" <<< $TAG || grep -q "1.11" <<< $TAG); then
-  export GOLANG_VERSION=1.16.7b7
+  export GOLANG_VERSION=1.16.9b7
 fi
 
 url="https://go-boringcrypto.storage.googleapis.com/go$GOLANG_VERSION.linux-amd64.tar.gz"


### PR DESCRIPTION
Bumps Go to 1.16.9b7 in `tetrateci/setup_boring_go.sh` for 1.11 FIPS builds. The bump is required to fix [CVE-2021-39293](https://groups.google.com/g/golang-announce/c/dx9d7IOseHw?pli=1).

cc: @deva26