### PR TITLE
Bumps Go version

### DIFF
--- a/tetrateci/setup_go.sh
+++ b/tetrateci/setup_go.sh
@@ -10,7 +10,7 @@ if $(grep -q "1.8" <<< $TAG || grep -q "1.9" <<< $TAG); then
 fi
 
 if $(grep -q "1.10" <<< $TAG || grep -q "1.11" <<< $TAG); then
-    export GOLANG_VERSION=1.16.7
+    export GOLANG_VERSION=1.16.9
 fi
 
 url="https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz"


### PR DESCRIPTION
Bumps the Go version to match the Go FIPS bump from https://github.com/tetratelabs/istio/pull/551.