### PR TITLE
ci: add support for Istio 1.12

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -19,12 +19,16 @@ jobs:
     env:
       RELEASE_GCS_PATH: gs://getistio-build/proxy-fips
     steps:
+      - name: Get the tag
+        id: get_tag
+        run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+
       - name: Get normalized tag
         id: get_minor_ver
         run: echo ::set-output name=NORMALIZED_TAG::$(echo $TAG | sed 's/test-//g' | sed 's/-.*//g')
         shell: bash
         env:
-          TAG: ${{ github.event.inputs.tag }}
+          TAG: ${{ steps.get_tag.outputs.TAG }}
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -43,8 +47,11 @@ jobs:
         id: check_already_built
         run: |
           SHA=$(git rev-parse --verify HEAD)
-          gsutil ls ${RELEASE_GCS_PATH} | grep ${SHA}
-          echo ::set-output name=should_build::$?
+          SHOULD_BUILD=1
+          if gsutil ls ${RELEASE_GCS_PATH} | grep ${SHA} ; then
+            SHOULD_BUILD=0
+          fi
+          echo ::set-output name=should_build::${SHOULD_BUILD}
 
       - name: Tweak make recipe
         if: ${{ steps.check_already_built.outputs.should_build == '1' }}
@@ -102,7 +109,10 @@ jobs:
     name: create-test-images
     runs-on: ubuntu-latest
     needs: [build_fips_proxy]
-    if: ${{ ! failure() }}
+    # 'if' condition causes this job to run even if some of the dependent jobs
+    # have been skipped, e.g. `build_fips_proxy`.
+    # see https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-not-requiring-dependent-jobs-to-be-successful
+    if: ${{ !cancelled() && !failure() }}
 
     steps:
       - name: checkout
@@ -155,11 +165,15 @@ jobs:
     name: eks-e2e-test
     runs-on: ubuntu-latest
     needs: [create-test-images]
+    # 'if' condition causes this job to run even if some of the dependent jobs
+    # have been skipped, e.g. `build_fips_proxy`.
+    # see https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-not-requiring-dependent-jobs-to-be-successful
+    if: ${{ !cancelled() && !failure() }}
 
     strategy:
       fail-fast: false
       matrix:
-        version: [1.19, 1.18, 1.17, 1.16]
+        version: ["1.21", "1.20", "1.19", "1.18"] # available versions according to https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
 
     steps:
       - name: checkout
@@ -216,13 +230,20 @@ jobs:
     name: gke-e2e-test
     runs-on: ubuntu-latest
     needs: [create-test-images]
+    # 'if' condition causes this job to run even if some of the dependent jobs
+    # have been skipped, e.g. `build_fips_proxy`.
+    # see https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-not-requiring-dependent-jobs-to-be-successful
+    if: ${{ !cancelled() && !failure() }}
 
     strategy:
       fail-fast: false
+      # available versions according to https://cloud.google.com/kubernetes-engine/versioning
       matrix:
         include:
-          - version: "1.21"
+          - version: "1.22"
             channel: "rapid"
+          - version: "1.21"
+            channel: "regular"
           - version: "1.20"
             channel: "regular"
           - version: "1.19"

--- a/tetrateci/1.12/test/skip.d/eks
+++ b/tetrateci/1.12/test/skip.d/eks
@@ -1,0 +1,42 @@
+# e2e tests to skip (until a long-term fix is found)
+#
+# Each line has format:
+#
+# ```text
+# <pkg>=<test1> <test2> <test3> ...
+# ```
+#
+# where
+# 1. <pkg>   - is a name of a package with Istio e2e tests, e.g.
+#              `istio.io/istio/tests/integration/pilot`
+# 2. <testN> - is a regexp that matches unit tests to skip, e.g.
+#              'TestA', 'TestA|TestB|TestC', 'TestA/case-b', etc.
+#              Each `<testN>` value will be translated into the
+#              `--istio.test.skip` option of the Istio Test Framework.
+#
+# A special case,
+#
+# ```text
+# <pkg>=*
+# ```
+#
+# indicates that tests for the package `<pkg>` should not be run at all.
+
+istio.io/istio/tests/integration/helm/upgrade=*
+
+istio.io/istio/tests/integration/pilot=*
+istio.io/istio/tests/integration/pilot/endpointslice=*
+istio.io/istio/tests/integration/pilot/revisions=TestMultiRevision
+
+istio.io/istio/tests/integration/security=*
+istio.io/istio/tests/integration/security/sds_ingress=*
+istio.io/istio/tests/integration/security/sds_tls_origination=TestSimpleTlsOrigination TestMutualTlsOrigination
+
+istio.io/istio/tests/integration/telemetry/stats/prometheus/nullvm=TestAccessLogs
+istio.io/istio/tests/integration/telemetry/tracing/opencensusagent=TestProxyTracing
+istio.io/istio/tests/integration/telemetry/tracing/zipkin/clienttracing=TestClientTracing
+istio.io/istio/tests/integration/telemetry/tracing/zipkin/servertracing=TestProxyTracing
+
+istio.io/istio/tests/integration/telemetry/stackdriver=*
+istio.io/istio/tests/integration/telemetry/stackdriver/api=*
+istio.io/istio/tests/integration/telemetry/stackdriver/vm=*

--- a/tetrateci/1.12/test/skip.d/gke
+++ b/tetrateci/1.12/test/skip.d/gke
@@ -1,0 +1,34 @@
+# e2e tests to skip (until a long-term fix is found)
+#
+# Each line has format:
+#
+# ```text
+# <pkg>=<test1> <test2> <test3> ...
+# ```
+#
+# where
+# 1. <pkg>   - is a name of a package with Istio e2e tests, e.g.
+#              `istio.io/istio/tests/integration/pilot`
+# 2. <testN> - is a regexp that matches unit tests to skip, e.g.
+#              'TestA', 'TestA|TestB|TestC', 'TestA/case-b', etc.
+#              Each `<testN>` value will be translated into the
+#              `--istio.test.skip` option of the Istio Test Framework.
+#
+# A special case,
+#
+# ```text
+# <pkg>=*
+# ```
+#
+# indicates that tests for the package `<pkg>` should not be run at all.
+
+istio.io/istio/tests/integration/helm/upgrade=*
+
+istio.io/istio/tests/integration/pilot=TestGateway TestIngress TestDescribe TestTraffic
+istio.io/istio/tests/integration/pilot/endpointslice=TestTraffic/jwt-claim-route
+
+istio.io/istio/tests/integration/security=TestAuthorization_IngressGateway TestAuthorization_EgressGateway TestIngressRequestAuthentication/ingress-authn
+
+istio.io/istio/tests/integration/telemetry/stackdriver=*
+istio.io/istio/tests/integration/telemetry/stackdriver/api=*
+istio.io/istio/tests/integration/telemetry/stackdriver/vm=*

--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -2,6 +2,7 @@
 
 set -o errexit
 set -o pipefail
+set -x
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 

--- a/tetrateci/setup_boring_go.sh
+++ b/tetrateci/setup_boring_go.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -u
 
 if $(grep -q "1.7" <<< $TAG); then
   export GOLANG_VERSION=1.14.12b4
@@ -11,6 +12,10 @@ fi
 
 if $(grep -q "1.10" <<< $TAG || grep -q "1.11" <<< $TAG); then
   export GOLANG_VERSION=1.16.9b7
+fi
+
+if [[ "${REL_BRANCH_VER:-${ISTIO_MINOR_VER}}" == "1.12" ]]; then
+  export GOLANG_VERSION=1.17.3b7
 fi
 
 url="https://go-boringcrypto.storage.googleapis.com/go$GOLANG_VERSION.linux-amd64.tar.gz"

--- a/tetrateci/setup_go.sh
+++ b/tetrateci/setup_go.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -u
 
 if $(grep -q "1.7" <<< $TAG); then
     export GOLANG_VERSION=1.14.12
@@ -11,6 +12,10 @@ fi
 
 if $(grep -q "1.10" <<< $TAG || grep -q "1.11" <<< $TAG); then
     export GOLANG_VERSION=1.16.9
+fi
+
+if [[ "${REL_BRANCH_VER:-${ISTIO_MINOR_VER}}" == "1.12" ]]; then
+    export GOLANG_VERSION=1.17.3
 fi
 
 url="https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz"

--- a/tetrateci/test_1.12.sh
+++ b/tetrateci/test_1.12.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Tetrate, Inc 2021 All Rights Reserved.
+
+set -e
+set -u
+set -x
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ROOTDIR=$( cd "${SCRIPTDIR}/.." && pwd )
+
+"${SCRIPTDIR}/version_check.py" && exit
+
+# shellcheck disable=SC1091
+source "${SCRIPTDIR}/setup_go.sh"
+
+COMMON_TEST_FLAGS=()
+
+if [[ "${CLUSTER}" == "gke" ]]; then
+  echo "Generating operator config for GKE"
+
+  # Overlay CNI Parameters for GCP : https://github.com/tetratelabs/getistio/issues/76
+  python3 -m pip install pyyaml --user && python3 "${SCRIPTDIR}/gen_iop.py"
+
+  COMMON_TEST_FLAGS+=( "-istio.test.kube.helm.iopFile=${SCRIPTDIR}/iop-gke-integration.yml" )
+fi
+
+PACKAGES=$(go list -tags=integ "${ROOTDIR}/tests/integration/...")
+
+echo "Starting Testing"
+
+FAILED_PACKAGES=()
+
+for pkg in $PACKAGES; do
+  echo "========================================================TESTING ${pkg} ========================================================"
+
+  SKIP_RULE=$( grep -F "${pkg}=" "${SCRIPTDIR}/${ISTIO_MINOR_VER}/test/skip.d/${CLUSTER}" 2>/dev/null || echo "" )
+  SKIP_TESTS=$( echo -n "${SKIP_RULE#${pkg}=}" )
+
+  if [[ "${SKIP_TESTS}" == "*" ]]; then
+    echo "Skipping according to the rule: ${SKIP_RULE}"
+    continue
+  fi
+
+  read -ra SKIP_TESTS_ARRAY <<< "${SKIP_TESTS}"
+
+  SKIP_TEST_FLAGS=()
+  for test in ${SKIP_TESTS_ARRAY[@]+"${SKIP_TESTS_ARRAY[@]}"} ; do
+    SKIP_TEST_FLAGS+=( "--istio.test.skip=${test}" )
+  done
+
+  go test \
+    -test.v \
+    -timeout 2h \
+    -tags=integ \
+    "${pkg}" \
+    --istio.test.select=-postsubmit,-flaky \
+    ${SKIP_TEST_FLAGS[@]+"${SKIP_TEST_FLAGS[@]}"} \
+    --istio.test.ci \
+    --istio.test.pullpolicy=IfNotPresent \
+    --istio.test.retries=1 \
+    ${COMMON_TEST_FLAGS[@]+"${COMMON_TEST_FLAGS[@]}"} \
+    || \
+    { FAILED_PACKAGES+=( "${pkg}" ) && echo "Test Failed: ${pkg}" ; }
+
+  find /tmp -mindepth 1 -maxdepth 1 -type d -name '*istio*' -exec sudo rm -f -- {} \;
+done
+
+echo "Testing Done"
+
+if [[ ${#FAILED_PACKAGES[@]} -gt 0 ]]; then
+  echo ""
+  echo "Some of the tests have failed :("
+  echo ""
+  echo "Packages with failed tests:"
+  for pkg in "${FAILED_PACKAGES[@]}"; do
+    echo "- ${pkg}"
+  done
+  exit 1
+fi

--- a/tetrateci/version_check.py
+++ b/tetrateci/version_check.py
@@ -8,6 +8,7 @@ version_matrix = {
     "1.9": {"1.17", "1.18", "1.19", "1.20"},
     "1.10": {"1.18", "1.19", "1.20", "1.21"},
     "1.11": {"1.18", "1.19", "1.20", "1.21", "1.22"},
+    "1.12": {"1.19", "1.20", "1.21", "1.22"}, # officially supported versions according to https://istio.io/latest/news/releases/1.12.x/announcing-1.12
 }
 
 istio_ver = os.environ.get("ISTIO_MINOR_VER")


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <yaroslav@tetrate.io>

## Summary

* This PR adds minimal changes required to build and test `Istio 1.12`
* To clarify, not all e2e tests run successfully. However, it seems impossible to fix all those failures in a fixed amount of time 

## Implementation Notes

* Since
  * not all e2e tests run successfully
  * test failures seem to be caused by the managed k8s clusters (`GKE`, `EKS`, etc)
  * it is not possible to fix all test failures in a time-boxed manner
* This PR introduces configuration for skipping certain tests
* The tests that have been skipped for now might be fixed in subsequent PRs, if reasonable

## About failing tests

* `Istio 1.12` is [officially supported](https://istio.io/latest/news/releases/1.12.x/announcing-1.12) on k8s `1.19`, `1.20`, `1.21`, `1.22`
* e2e tests fail differently on various k8s versions: less tests fail on `1.19`, (slightly) more tests fail on newer versions
* less e2e tests fail on `GKE`, more tests fail on `EKS`
* there are some issues with testing on AWS EKS - provisioning of test clusters fails. Might be caused by AWS quotas
