### PR TITLE
use 1.17 for istio 1.11 and 1.12

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -152,6 +152,11 @@ jobs:
         env:
           TAG: ${{ steps.get_tag.outputs.TAG }}
 
+      - name: apply patches required in the context of e2e tests
+        run: tetrateci/apply_e2e_build_patches.sh
+        env:
+          ISTIO_MINOR_VER: ${{ steps.get_minor_ver.outputs.REL_BRANCH_VER }}
+
       - name: build and push images
         run: bash ./tetrateci/create_istio_release.sh
         env:

--- a/tetrateci/apply_e2e_build_patches.sh
+++ b/tetrateci/apply_e2e_build_patches.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Tetrate, Inc 2021 All Rights Reserved.
+
+#
+# Apply patches to the Istio code base that are necessary to fix e2e tests.
+#
+# E.g., after we bumped version of Go from `1.16` to `1.17`, e2e tests of
+# `Istio 1.11` started failing.
+#
+# To fix e2e tests, we had to backport changes from `Istio 1.12`.
+#
+# However, since required changes affected only test code and test images,
+# we didn't want to include them into the release build.
+#
+
+set -e
+set -u
+set -x
+
+SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+while IFS= read -r -d '' patch
+do
+    git apply "${patch}"
+done < <(find "${SCRIPTDIR}/patches/build/e2e/${ISTIO_MINOR_VER}" -type f -name '*.patch' -print0)

--- a/tetrateci/patches/build/e2e/1.11/0001-Allow-turning-off-ALPN-in-echo-server-35447.patch
+++ b/tetrateci/patches/build/e2e/1.11/0001-Allow-turning-off-ALPN-in-echo-server-35447.patch
@@ -1,0 +1,173 @@
+From a73e4473ebf9f35d15d825077253993f6e770020 Mon Sep 17 00:00:00 2001
+From: John Howard <howardjohn@google.com>
+Date: Mon, 4 Oct 2021 11:06:39 -0700
+Subject: [PATCH] Allow turning off ALPN in echo server (#35447)
+
+---
+ pkg/test/echo/cmd/server/main.go              |  3 +++
+ pkg/test/echo/common/model.go                 |  5 +++++
+ pkg/test/echo/server/endpoint/http.go         |  6 +++++-
+ pkg/test/echo/server/endpoint/instance.go     |  1 +
+ pkg/test/echo/server/instance.go              |  2 ++
+ .../components/echo/kube/deployment.go        |  3 +++
+ .../security/ca_custom_root/main_test.go      | 21 +++++++++++--------
+ 7 files changed, 31 insertions(+), 10 deletions(-)
+
+diff --git a/pkg/test/echo/cmd/server/main.go b/pkg/test/echo/cmd/server/main.go
+index e32a07dff5..30bc9d7a01 100644
+--- a/pkg/test/echo/cmd/server/main.go
++++ b/pkg/test/echo/cmd/server/main.go
+@@ -48,6 +48,7 @@ var (
+ 	crt              string
+ 	key              string
+ 	istioVersion     string
++	disableALPN      bool
+ 
+ 	loggingOptions = log.DefaultOptions()
+ 
+@@ -123,6 +124,7 @@ var (
+ 				Cluster:               cluster,
+ 				IstioVersion:          istioVersion,
+ 				UDSServer:             uds,
++				DisableALPN:           disableALPN,
+ 			})
+ 
+ 			if err := s.Start(); err != nil {
+@@ -164,6 +166,7 @@ func init() {
+ 	rootCmd.PersistentFlags().StringVar(&crt, "crt", "", "gRPC TLS server-side certificate")
+ 	rootCmd.PersistentFlags().StringVar(&key, "key", "", "gRPC TLS server-side key")
+ 	rootCmd.PersistentFlags().StringVar(&istioVersion, "istio-version", "", "Istio sidecar version")
++	rootCmd.PersistentFlags().BoolVar(&disableALPN, "disable-alpn", disableALPN, "disable ALPN negotiation")
+ 
+ 	loggingOptions.AttachCobraFlags(rootCmd)
+ 
+diff --git a/pkg/test/echo/common/model.go b/pkg/test/echo/common/model.go
+index 0433f36ef8..2e721ebdd7 100644
+--- a/pkg/test/echo/common/model.go
++++ b/pkg/test/echo/common/model.go
+@@ -28,6 +28,11 @@ type TLSSettings struct {
+ 	Hostname string
+ 	// If set to true, the cert will be provisioned by proxy, and extra cert volume will be mounted.
+ 	ProxyProvision bool
++	// AcceptAnyALPN, if true, will make the server accept ANY ALPNs. This comes at the expense of
++	// allowing h2 negotiation and being able to detect the negotiated ALPN (as there is none), because
++	// Golang doesn't like us doing this (https://github.com/golang/go/issues/46310).
++	// This is useful when the server is simulating Envoy which does unconventional things with ALPN.
++	AcceptAnyALPN bool
+ }
+ 
+ // Port represents a network port where a service is listening for
+diff --git a/pkg/test/echo/server/endpoint/http.go b/pkg/test/echo/server/endpoint/http.go
+index 59aa38abd6..2d93d55fa4 100644
+--- a/pkg/test/echo/server/endpoint/http.go
++++ b/pkg/test/echo/server/endpoint/http.go
+@@ -86,9 +86,13 @@ func (s *httpInstance) Start(onReady OnReadyFunc) error {
+ 		if cerr != nil {
+ 			return fmt.Errorf("could not load TLS keys: %v", cerr)
+ 		}
++		nextProtos := []string{"h2", "http/1.1", "http/1.0"}
++		if s.DisableALPN {
++			nextProtos = nil
++		}
+ 		config := &tls.Config{
+ 			Certificates: []tls.Certificate{cert},
+-			NextProtos:   []string{"h2", "http/1.1", "http/1.0"},
++			NextProtos:   nextProtos,
+ 			GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+ 				// There isn't a way to pass through all ALPNs presented by the client down to the
+ 				// HTTP server to return in the response. However, for debugging, we can at least log
+diff --git a/pkg/test/echo/server/endpoint/instance.go b/pkg/test/echo/server/endpoint/instance.go
+index f2ccbf5086..f6a0c7de16 100644
+--- a/pkg/test/echo/server/endpoint/instance.go
++++ b/pkg/test/echo/server/endpoint/instance.go
+@@ -40,6 +40,7 @@ type Config struct {
+ 	Port          *common.Port
+ 	ListenerIP    string
+ 	IstioVersion  string
++	DisableALPN   bool
+ }
+ 
+ // Instance of an endpoint that serves the Echo application on a single port/protocol.
+diff --git a/pkg/test/echo/server/instance.go b/pkg/test/echo/server/instance.go
+index b3040fcea7..ccf0557855 100644
+--- a/pkg/test/echo/server/instance.go
++++ b/pkg/test/echo/server/instance.go
+@@ -47,6 +47,7 @@ type Config struct {
+ 	Cluster               string
+ 	Dialer                common.Dialer
+ 	IstioVersion          string
++	DisableALPN           bool
+ }
+ 
+ func (c Config) String() string {
+@@ -164,6 +165,7 @@ func (s *Instance) newEndpoint(port *common.Port, udsServer string) (endpoint.In
+ 		TLSKey:        s.TLSKey,
+ 		Dialer:        s.Dialer,
+ 		ListenerIP:    ip,
++		DisableALPN:   s.DisableALPN,
+ 		IstioVersion:  s.IstioVersion,
+ 	})
+ }
+diff --git a/pkg/test/framework/components/echo/kube/deployment.go b/pkg/test/framework/components/echo/kube/deployment.go
+index 667a79fa7c..75079eb210 100644
+--- a/pkg/test/framework/components/echo/kube/deployment.go
++++ b/pkg/test/framework/components/echo/kube/deployment.go
+@@ -221,6 +221,9 @@ spec:
+ {{- if $.TLSSettings }}
+           - --crt=/etc/certs/custom/cert-chain.pem
+           - --key=/etc/certs/custom/key.pem
++{{- if $.TLSSettings.AcceptAnyALPN}}
++          - --disable-alpn
++{{- end }}
+ {{- else }}
+           - --crt=/cert.crt
+           - --key=/cert.key
+diff --git a/tests/integration/security/ca_custom_root/main_test.go b/tests/integration/security/ca_custom_root/main_test.go
+index 095a242184..293bc5c085 100644
+--- a/tests/integration/security/ca_custom_root/main_test.go
++++ b/tests/integration/security/ca_custom_root/main_test.go
+@@ -141,9 +141,10 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
+ 				},
+ 			},
+ 			TLSSettings: &common.TLSSettings{
+-				RootCert:   rootCert,
+-				ClientCert: clientCert,
+-				Key:        Key,
++				RootCert:      rootCert,
++				ClientCert:    clientCert,
++				Key:           Key,
++				AcceptAnyALPN: true,
+ 			},
+ 		}).
+ 		WithConfig(echo.Config{
+@@ -165,9 +166,10 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
+ 				},
+ 			},
+ 			TLSSettings: &common.TLSSettings{
+-				RootCert:   rootCert,
+-				ClientCert: clientCert,
+-				Key:        Key,
++				RootCert:      rootCert,
++				ClientCert:    clientCert,
++				Key:           Key,
++				AcceptAnyALPN: true,
+ 			},
+ 		}).
+ 		WithConfig(echo.Config{
+@@ -190,9 +192,10 @@ func SetupApps(ctx resource.Context, apps *EchoDeployments) error {
+ 				},
+ 			},
+ 			TLSSettings: &common.TLSSettings{
+-				RootCert:   rootCertAlt,
+-				ClientCert: clientCertAlt,
+-				Key:        keyAlt,
++				RootCert:      rootCertAlt,
++				ClientCert:    clientCertAlt,
++				Key:           keyAlt,
++				AcceptAnyALPN: true,
+ 			},
+ 		}).
+ 		WithConfig(echo.Config{
+-- 
+2.21.1 (Apple Git-122.3)
+

--- a/tetrateci/patches/build/e2e/1.11/README.md
+++ b/tetrateci/patches/build/e2e/1.11/README.md
@@ -1,0 +1,14 @@
+# Patches to Istio 1.11
+
+## 0001-Allow-turning-off-ALPN-in-echo-server-35447.patch
+
+### Why do we need it?
+
+Integration tests of `Istio 1.11` were relying on certain behaviour
+of the HTTPS server from the Go standard library.
+
+In `Go 1.17`, behaviour of the HTTPS server has changed and tests started failing.
+
+In `Istio 1.12` they changed integration tests in order to be able to upgrade to `Go 1.17`.
+
+See https://github.com/istio/istio/pull/35447

--- a/tetrateci/setup_boring_go.sh
+++ b/tetrateci/setup_boring_go.sh
@@ -10,12 +10,16 @@ if $(grep -q "1.8" <<< $TAG || grep -q "1.9" <<< $TAG); then
   export GOLANG_VERSION=1.15.8b5
 fi
 
-if $(grep -q "1.10" <<< $TAG || grep -q "1.11" <<< $TAG); then
+if $(grep -q "1.10" <<< $TAG); then
   export GOLANG_VERSION=1.16.9b7
 fi
 
+if $(grep -q "1.11" <<< $TAG); then
+  export GOLANG_VERSION=1.17.6b7
+fi
+
 if [[ "${REL_BRANCH_VER:-${ISTIO_MINOR_VER}}" == "1.12" ]]; then
-  export GOLANG_VERSION=1.17.3b7
+  export GOLANG_VERSION=1.17.6b7
 fi
 
 url="https://go-boringcrypto.storage.googleapis.com/go$GOLANG_VERSION.linux-amd64.tar.gz"

--- a/tetrateci/setup_go.sh
+++ b/tetrateci/setup_go.sh
@@ -10,12 +10,16 @@ if $(grep -q "1.8" <<< $TAG || grep -q "1.9" <<< $TAG); then
     export GOLANG_VERSION=1.15.7
 fi
 
-if $(grep -q "1.10" <<< $TAG || grep -q "1.11" <<< $TAG); then
+if $(grep -q "1.10" <<< $TAG); then
     export GOLANG_VERSION=1.16.9
 fi
 
+if $(grep -q "1.11" <<< $TAG); then
+    export GOLANG_VERSION=1.17.6
+fi
+
 if [[ "${REL_BRANCH_VER:-${ISTIO_MINOR_VER}}" == "1.12" ]]; then
-    export GOLANG_VERSION=1.17.3
+    export GOLANG_VERSION=1.17.6
 fi
 
 url="https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz"

--- a/tetrateci/test_1.11.sh
+++ b/tetrateci/test_1.11.sh
@@ -18,6 +18,9 @@ COMMON_TEST_FLAGS=()
 
 echo "Applying patches...."
 
+# Apply the same patches that were applies when building test images
+"${SCRIPTDIR}/apply_e2e_build_patches.sh"
+
 git apply "${SCRIPTDIR}/patches/common/increase-dashboard-timeout.1.11.patch"
 
 if [[ "${CLUSTER}" == "gke" ]]; then


### PR DESCRIPTION
I'm not sure if I should be changing the version for istio 1.10 too...

Resolves a series of CVEs:
https://nvd.nist.gov/vuln/detail/CVE-2021-29923
https://nvd.nist.gov/vuln/detail/CVE-2021-39293
https://nvd.nist.gov/vuln/detail/CVE-2021-44716
https://nvd.nist.gov/vuln/detail/CVE-2021-38297
https://nvd.nist.gov/vuln/detail/CVE-2021-41772
https://nvd.nist.gov/vuln/detail/CVE-2021-41771
