### PR TITLE
Add node trigger back

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -385,6 +385,8 @@ const (
 	NamespaceUpdate TriggerReason = "namespace"
 	// ClusterUpdate describes a push triggered by a Cluster change
 	ClusterUpdate TriggerReason = "cluster"
+	// NodeTrigger describes a push triggered due to node event
+	NodeTrigger TriggerReason = "node"
 )
 
 // Merge two update requests together

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -680,7 +680,7 @@ func (c *Controller) onNodeEvent(obj interface{}, event model.Event) error {
 	if updatedNeeded && c.updateServiceNodePortAddresses() {
 		c.opts.XDSUpdater.ConfigUpdate(&model.PushRequest{
 			Full:   true,
-			Reason: []model.TriggerReason{model.ServiceUpdate},
+			Reason: []model.TriggerReason{model.ServiceUpdate, model.NodeTrigger},
 		})
 	}
 	return nil


### PR DESCRIPTION
As per discussion making node port address changes have a trigger reason of
both ServiceUpdate (upstream change) and our custom NodeTrigger.

This should be part of https://github.com/tetratelabs/istio/commit/d7de3c2f7f10144d7f6bef69b4d08d3fcb4141ab and on
the next rebase these should be squashed together.