### PR TITLE
Add istio  1.13 variable in setup_go scripts

### DIFF
--- a/tetrateci/setup_boring_go.sh
+++ b/tetrateci/setup_boring_go.sh
@@ -18,7 +18,7 @@ if $(grep -q "1.11" <<< $TAG || grep -q "1.12" <<< $TAG); then
   export GOLANG_VERSION=1.17.6b7
 fi
 
-if [[ "${REL_BRANCH_VER:-${ISTIO_MINOR_VER}}" == "1.12" ]]; then
+if [[ "${REL_BRANCH_VER:-${ISTIO_MINOR_VER}}" == "1.13" ]]; then
   export GOLANG_VERSION=1.17.8b7
 fi
 

--- a/tetrateci/setup_boring_go.sh
+++ b/tetrateci/setup_boring_go.sh
@@ -14,12 +14,12 @@ if $(grep -q "1.10" <<< $TAG); then
   export GOLANG_VERSION=1.16.9b7
 fi
 
-if $(grep -q "1.11" <<< $TAG); then
+if $(grep -q "1.11" <<< $TAG || grep -q "1.12" <<< $TAG); then
   export GOLANG_VERSION=1.17.6b7
 fi
 
 if [[ "${REL_BRANCH_VER:-${ISTIO_MINOR_VER}}" == "1.12" ]]; then
-  export GOLANG_VERSION=1.17.6b7
+  export GOLANG_VERSION=1.17.8b7
 fi
 
 url="https://go-boringcrypto.storage.googleapis.com/go$GOLANG_VERSION.linux-amd64.tar.gz"

--- a/tetrateci/setup_go.sh
+++ b/tetrateci/setup_go.sh
@@ -14,12 +14,12 @@ if $(grep -q "1.10" <<< $TAG); then
     export GOLANG_VERSION=1.16.9
 fi
 
-if $(grep -q "1.11" <<< $TAG); then
+if $(grep -q "1.11" <<< $TAG || grep -q "1.12" <<< $TAG); then
     export GOLANG_VERSION=1.17.6
 fi
 
-if [[ "${REL_BRANCH_VER:-${ISTIO_MINOR_VER}}" == "1.12" ]]; then
-    export GOLANG_VERSION=1.17.6
+if [[ "${REL_BRANCH_VER:-${ISTIO_MINOR_VER}}" == "1.13" ]]; then
+    export GOLANG_VERSION=1.17.8
 fi
 
 url="https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz"


### PR DESCRIPTION
Workflows for e2e and makerelease are breaking because release variable 1.13 is not defined in go setup scripts