### PR TITLE
Added bom utility as build is failing when creating sbom

### DIFF
--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -16,8 +16,11 @@ else
 fi
 
 ## Set up release-builder
-go install sigs.k8s.io/bom/cmd/bom@latest
+
+# BOM is needed for generating bill of materials, required by Istio since 1.13, https://github.com/istio/release-builder/pull/893
+go install sigs.k8s.io/bom/cmd/bom@v0.2.2
 cp go/bin/bom /usr/local/bin/
+
 sudo gem install fpm
 sudo apt-get install go-bindata -y
 export BRANCH=release-${REL_BRANCH_VER}

--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -16,6 +16,8 @@ else
 fi
 
 ## Set up release-builder
+go install sigs.k8s.io/bom/cmd/bom@latest
+cp go/bin/bom /usr/local/bin/
 sudo gem install fpm
 sudo apt-get install go-bindata -y
 export BRANCH=release-${REL_BRANCH_VER}


### PR DESCRIPTION
Build is failing as its not able for find bom utility. SBOM generation is a new add-on in istio 1.13
https://github.com/istio/release-builder/pull/893