### PR TITLE
1.13 fix

### DIFF
--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -19,7 +19,9 @@ fi
 
 # BOM is needed for generating bill of materials, required by Istio since 1.13, https://github.com/istio/release-builder/pull/893
 go install sigs.k8s.io/bom/cmd/bom@v0.2.2
-cp go/bin/bom /usr/local/bin/
+pwd
+go env
+cp /home/runner/go/bin/bom /usr/local/bin/
 
 sudo gem install fpm
 sudo apt-get install go-bindata -y

--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -16,8 +16,11 @@ else
 fi
 
 ## Set up release-builder
-go install sigs.k8s.io/bom/cmd/bom@latest
+
+# BOM is needed for generating bill of materials, required by Istio since 1.13, https://github.com/istio/release-builder/pull/893
+go install sigs.k8s.io/bom/cmd/bom@v0.2.2
 cp go/bin/bom /usr/local/bin/
+
 sudo gem install fpm
 sudo apt-get install go-bindata -y
 export BRANCH=release-${REL_BRANCH_VER}

--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -19,8 +19,6 @@ fi
 
 # BOM is needed for generating bill of materials, required by Istio since 1.13, https://github.com/istio/release-builder/pull/893
 go install sigs.k8s.io/bom/cmd/bom@v0.2.2
-pwd
-go env
 cp /home/runner/go/bin/bom /usr/local/bin/
 
 sudo gem install fpm
@@ -77,6 +75,9 @@ cp -r ../istio .
 mkdir /tmp/istio-release
 go run main.go build --manifest manifest.docker.yaml
 # go run main.go validate --release /tmp/istio-release/out # seems like it fails if not all the targets are generated
+
+#loading pilot image manually since docker container create command is failing due to unavailbilty of pilot image locally
+docker load -i /tmp/istio-release/out/docker/pilot.tar.gz
 
 CONTAINER_ID=$(docker create $HUB/pilot:$TAG)
 docker cp $CONTAINER_ID:/usr/local/bin/pilot-discovery pilot-bin

--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -16,6 +16,8 @@ else
 fi
 
 ## Set up release-builder
+go install sigs.k8s.io/bom/cmd/bom@latest
+cp go/bin/bom /usr/local/bin/
 sudo gem install fpm
 sudo apt-get install go-bindata -y
 export BRANCH=release-${REL_BRANCH_VER}


### PR DESCRIPTION
fixing container create error after completion of docker images build.

`2022-03-23T16:17:43.290435Z	info	Built release at /tmp/istio-release/out
++ docker create ***/pilot:1.13.2-tetrate-v2-prabhjot
Unable to find image '***/pilot:1.13.2-tetrate-v2-prabhjot' locally
Error response from daemon: manifest for ***/pilot:1.13.2-tetrate-v2-prabhjot not found: manifest unknown: manifest unknown
+ CONTAINER_ID=
Error: Process completed with exit code 1.`