### PR TITLE
version matrix update for e2e tests and rearranging /tmp/istio-release cleanup

### DIFF
--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -93,8 +93,8 @@ if [ ${TAG} =~ "fips" ]; then
 fi
 
 go run main.go publish --release /tmp/istio-release/out --dockerhub $HUB
-echo "Cleaning up the docker build...."
-[ -d "/tmp/istio-release" ] && sudo rm -rf /tmp/istio-release
+echo "Cleaning up the istio source artificats...."
+sudo rm -rf /tmp/istio-release/sources/
 
 # If RELEASE, Build Archives
 if [[ -z ${TEST:-} ]]; then
@@ -116,5 +116,7 @@ if [[ -z ${TEST:-} ]]; then
         cloudsmith push raw tetrate/getistio /tmp/istio-release/out/$package
     done
 fi
+echo "Cleaning /tmp/istio...."
+[ -d "/tmp/istio-release" ] && sudo rm -rf /tmp/istio-release
 
 echo "Done building and pushing the artifacts."

--- a/tetrateci/version_check.py
+++ b/tetrateci/version_check.py
@@ -9,7 +9,7 @@ version_matrix = {
     "1.10": {"1.18", "1.19", "1.20", "1.21"},
     "1.11": {"1.18", "1.19", "1.20", "1.21", "1.22"},
     "1.12": {"1.19", "1.20", "1.21", "1.22"},
-    "1.12": {"1.20", "1.21", "1.22", "1.23"}, # officially supported versions according to https://istio.io/latest/news/releases/1.13.x/announcing-1.13
+    "1.13": {"1.20", "1.21", "1.22", "1.23"}, # officially supported versions according to https://istio.io/latest/news/releases/1.13.x/announcing-1.13
 }
 
 istio_ver = os.environ.get("ISTIO_MINOR_VER")

--- a/tetrateci/version_check.py
+++ b/tetrateci/version_check.py
@@ -8,7 +8,7 @@ version_matrix = {
     "1.9": {"1.17", "1.18", "1.19", "1.20"},
     "1.10": {"1.18", "1.19", "1.20", "1.21"},
     "1.11": {"1.18", "1.19", "1.20", "1.21", "1.22"},
-    "1.12": {"1.19", "1.20", "1.21", "1.22"},
+    "1.12": {"1.19", "1.20", "1.21", "1.22"}, # officially supported versions according to https://istio.io/latest/news/releases/1.12.x/announcing-1.12
     "1.13": {"1.20", "1.21", "1.22", "1.23"}, # officially supported versions according to https://istio.io/latest/news/releases/1.13.x/announcing-1.13
 }
 

--- a/tetrateci/version_check.py
+++ b/tetrateci/version_check.py
@@ -8,7 +8,8 @@ version_matrix = {
     "1.9": {"1.17", "1.18", "1.19", "1.20"},
     "1.10": {"1.18", "1.19", "1.20", "1.21"},
     "1.11": {"1.18", "1.19", "1.20", "1.21", "1.22"},
-    "1.12": {"1.19", "1.20", "1.21", "1.22"}, # officially supported versions according to https://istio.io/latest/news/releases/1.12.x/announcing-1.12
+    "1.12": {"1.19", "1.20", "1.21", "1.22"},
+    "1.12": {"1.20", "1.21", "1.22", "1.23"}, # officially supported versions according to https://istio.io/latest/news/releases/1.13.x/announcing-1.13
 }
 
 istio_ver = os.environ.get("ISTIO_MINOR_VER")


### PR DESCRIPTION
Fixing make_release workflow. Archiving of istio build failing because sbom archive  creation has dependency on docker folder in istio-release/out folder.

```
2022-03-24T12:38:12.182485Z	warn	skipping license for enhancements
Error: failed to build: failed to generate sbom: failed to walk directory /tmp/istio-release/out/docker: lstat /tmp/istio-release/out/docker: no such file or directory
exit status 1
Error: Process completed with exit code 1.
```
