### PR TITLE
Removing mac-os,win OS for fips build.

### DIFF
--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -109,7 +109,9 @@ if [[ -z ${TEST:-} ]]; then
     # if FIPS, need to use native go as boringgo as of now can't build archives for different platforms
     if [[ ${TAG} =~ "fips" ]]; then
         sudo rm -rf /usr/local/go
-        source ${BASEDIR}/tetrateci/setup_go.sh
+        source ${BASEDIR}/tetrateci/setup_boring_go.sh
+        # for fips build, only linux-amd64 artifacts are needed since linux-amd64 is the only fips compliant OS Arch in the list" 
+        sed -i 's/"linux-amd64"\s,\s"linux-armv7",\s"linux-arm64",\s"osx",\s"osx-arm64",\s"win"/"linux-amd64"/g' pkg/build/archive.go
     fi
     echo "Cleaning up older artifacts created in docker build stage ..."
     sudo rm -rf /tmp/istio-release/sources/


### PR DESCRIPTION
Keeping amd64,linux arch OS in  release-builder/pkg/build.archive.go as its the only fips compliant in the list.

We get this error for other distributions.
```
GOOS=darwin GOARCH=amd64 LDFLAGS='-extldflags -static' common/scripts/gobuild.sh /tmp/istio-release/work/src/istio.io/istio/out/linux_amd64/release/istioctl-osx ./istioctl/cmd/istioctl
# runtime/cgo
gcc: error: x86_64: No such file or directory
gcc: error: unrecognized command line option '-arch'; did you mean '-march='?

real	0m1.185s
user	0m4.389s
sys	0m0.755s
Makefile.core.mk:429: recipe for target '/tmp/istio-release/work/src/istio.io/istio/out/linux_amd64/release/istioctl-osx' failed
```
