### PR TITLE
Enabling cgo to create different builds of istioctl for fips

### DIFF
--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -109,12 +109,12 @@ if [[ -z ${TEST:-} ]]; then
     # if FIPS, need to use native go as boringgo as of now can't build archives for different platforms
     if [[ ${TAG} =~ "fips" ]]; then
         sudo rm -rf /usr/local/go
-        source ${BASEDIR}/tetrateci/setup_boring_go.sh
-        # for fips build, only linux-amd64 artifacts are needed since linux-amd64 is the only fips compliant OS Arch in the list" 
-        sed -i 's/"linux-amd64",\s"linux-armv7",\s"linux-arm64",\s"osx",\s"osx-arm64",\s"win"/"linux-amd64"/g' pkg/build/archive.go
+        source ${BASEDIR}/tetrateci/setup_go.sh
     fi
     echo "Cleaning up older artifacts created in docker build stage ..."
-    sudo rm -rf /tmp/istio-release/sources/
+    sudo rm -rf /tmp/istio-release/sources/ && sudo rm -rf /tmp/istio-release/work/
+    #disabling cgo flag
+    sed -i '/then export CGO_ENABLED=1/c\export CGO_ENABLED=0' istio/common/scripts/gobuild.sh
     go run main.go build --manifest manifest.archive.yaml
 
     python3 -m pip install --upgrade cloudsmith-cli --user

--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -76,7 +76,7 @@ echo "Enabling CGO for FIPS build via CGO_ENABLED=1 to istio/common/scripts/gobu
 
 if [[ ${TAG} =~ "fips" ]]; then
   text="if [[ "\${GOARCH}" == "amd64" ]]; then export CGO_ENABLED=1; else export CGO_ENABLED=0; fi"
-  sed -i '52s/.*/'"$text"'/g' istio/common/scripts/gobuild.sh
+  sed -i 's/export CGO_ENABLED=${CGO_ENABLED:-0}/'"$text"'/g' istio/common/scripts/gobuild.sh
 fi
 # Build Docker Images
 mkdir /tmp/istio-release
@@ -110,11 +110,11 @@ if [[ -z ${TEST:-} ]]; then
     if [[ ${TAG} =~ "fips" ]]; then
         sudo rm -rf /usr/local/go
         source ${BASEDIR}/tetrateci/setup_go.sh
+        #disabling cgo flag
+        sed -i '/then export CGO_ENABLED=1/c\export CGO_ENABLED=0' istio/common/scripts/gobuild.sh
     fi
     echo "Cleaning up older artifacts created in docker build stage ..."
     sudo rm -rf /tmp/istio-release/sources/ && sudo rm -rf /tmp/istio-release/work/
-    #disabling cgo flag
-    sed -i '/then export CGO_ENABLED=1/c\export CGO_ENABLED=0' istio/common/scripts/gobuild.sh
     go run main.go build --manifest manifest.archive.yaml
 
     python3 -m pip install --upgrade cloudsmith-cli --user

--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -75,6 +75,8 @@ cp -r ../istio .
 echo "Enabling CGO for FIPS build via CGO_ENABLED=1 to istio/common/scripts/gobuild.sh"
 
 if [[ ${TAG} =~ "fips" ]]; then
+  echo "Checking if the upstream file is not changed"
+  if ! grep -q 'CGO_ENABLED=${CGO_ENABLED:-0}' istio/common/scripts/gobuild.sh;then exit 1;fi
   text="if [[ "\${GOARCH}" == "amd64" ]]; then export CGO_ENABLED=1; else export CGO_ENABLED=0; fi"
   sed -i 's/export CGO_ENABLED=${CGO_ENABLED:-0}/'"$text"'/g' istio/common/scripts/gobuild.sh
 fi


### PR DESCRIPTION
Using native go and cgo=0 for building istioctl artifacts.