### PR TITLE
Deleting extra folders to reclaim more space

### DIFF
--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -28,10 +28,10 @@ cd ..
 git clone https://github.com/istio/release-builder --branch ${BRANCH}
 
 
-# HACK : the github runner runs out of space sometimes so removing the 21 GB dotnet folder
+# HACK : the github runner runs provides 14 GB free space. (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).
 # Temporary thing, we should be moving to a custom runner instead.
-echo "Deleting /usr/share/dotnet to reclaim space"
-[ -d "/usr/share/dotnet" ] && sudo rm -rf /usr/share/dotnet
+echo "Deleting /usr/share/dotnet, /opt/ghc, /usr/local/share/boost to reclaim space"
+[ -d "/usr/share/dotnet" ] && sudo rm -rf /usr/share/dotnet && [ -d "/opt/ghc" ] && sudo rm -rf /opt/ghc && [ -d "/usr/local/share/boost" ] && sudo rm -rf /usr/local/share/boost
 echo "Deletetion complete"
 
 # HACK : This is needed during istio build for istiod to serve version command

--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -31,8 +31,8 @@ git clone https://github.com/istio/release-builder --branch ${BRANCH}
 # HACK : the github runner runs provides 14 GB free space. (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).
 # Temporary thing, we should be moving to a custom runner instead.
 echo "Deleting /usr/share/dotnet, /opt/ghc, /usr/local/share/boost to reclaim space"
-[ -d "/usr/share/dotnet" ] && sudo rm -rf /usr/share/dotnet && [ -d "/opt/ghc" ] && sudo rm -rf /opt/ghc && [ -d "/usr/local/share/boost" ] && sudo rm -rf /usr/local/share/boost
-echo "Deletetion complete"
+for i in /usr/share/dotnet /opt/ghc /usr/local/share/boost; do echo deleting folder $i; [ -d $i ] && rm -rf "$i" ; done
+echo "Deletion complete"
 
 # HACK : This is needed during istio build for istiod to serve version command
 export ISTIO_VERSION=$TAG


### PR DESCRIPTION
Build for 1.13.2 fails due to no disk space issue.
Although the actual artifact size in /tmp/istio-release is around 3Gb for archiving. We can try the solution proposed in this GH issue.
https://github.com/actions/virtual-environments/issues/2840

```
GOOS=windows LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh /tmp/istio-release/work/src/istio.io/istio/out/linux_amd64/release/istioctl-win.exe ./istioctl/cmd/istioctl
sys	0m38.859s
go: downloading github.com/inconshreveable/mousetrap v1.0.0
go: downloading github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1
# istio.io/istio/istioctl/cmd/istioctl
/usr/local/go/pkg/tool/linux_amd64/link: mapping output file failed: no space left on device

real	3m44.002s
user	6m27.267s
sys	0m42.442s
make: *** [Makefile.core.mk:425: /tmp/istio-release/work/src/istio.io/istio/out/linux_amd64/release/istioctl-win.exe] Error 2
Error: failed to build: failed to build Archive: failed to make istioctl: exit status 2
exit status 1
Error: Process completed with exit code 1.
```

