### PR TITLE
prunning docker images to reclaim more space from host

### DIFF
--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -117,6 +117,8 @@ if [[ -z ${TEST:-} ]]; then
     fi
     echo "Cleaning up older artifacts created in docker build stage ..."
     sudo rm -rf /tmp/istio-release/sources/ && sudo rm -rf /tmp/istio-release/work/
+    echo "Prunning docker images to reclaim more space for 1.13.x-fips release"
+    for i in `docker images | grep -v istioctl | awk {'print $3'}`; do echo pruning $i; docker rmi $i --force; done
     go run main.go build --manifest manifest.archive.yaml
 
     python3 -m pip install --upgrade cloudsmith-cli --user


### PR DESCRIPTION
We are running out of disk space on hosted runner. Tried https://github.com/actions/virtual-environments/issues/2840.
we can try to prune docker images once they are pushed to cloudsmith as docker images in host consume space from /var/lib/docker which is mounted on / partition. 