### PR TITLE
Context: https://github.com/tetrateio/tid-internal/issues/45

### DIFF
--- a/tetrateci/create_istio_release.sh
+++ b/tetrateci/create_istio_release.sh
@@ -47,7 +47,6 @@ if [[ ${TAG} =~ "fips" ]]; then
 	PROXY_DISTROLESS_BASE=$(grep 'as distroless' ${BASEDIR}/pilot/docker/Dockerfile.proxyv2)
 	# Escape '/'
 	PROXY_DISTROLESS_BASE_ESCAPED=$(sed 's/\//\\\//g' <<< ${PROXY_DISTROLESS_BASE})
-	sed -i "s/.*as distroless/${PROXY_DISTROLESS_BASE_ESCAPED}/" ${BASEDIR}/pilot/docker/Dockerfile.pilot
 	sed -i "s/.*as distroless/${PROXY_DISTROLESS_BASE_ESCAPED}/" ${BASEDIR}/operator/docker/Dockerfile.operator
 
     export ISTIO_ENVOY_BASE_URL=https://storage.googleapis.com/getistio-build/proxy-fips


### PR DESCRIPTION
Using distroless base image instead for proxyv2 base image for building pilot image since istiod pod is not coming up for fips build with distroless images due to below error.
```
 2022-05-05T20:16:52.970133Z	error	failed to create discovery service: error initializing kube client: failed reading mesh config: cannot read mesh config file open ./etc/istio/config/mesh: permission denied
Error: failed to create discovery service: error initializing kube client: failed reading mesh config: cannot read mesh config file open ./etc/istio/config/mesh: permission denied
```
`FROM gcr.io/istio-release/distroless:${BASE_VERSION} as distroless`

Context : https://github.com/tetrateio/tid-internal/issues/45